### PR TITLE
Add faction philosophy system

### DIFF
--- a/docs/faction_philosophy.md
+++ b/docs/faction_philosophy.md
@@ -1,0 +1,26 @@
+# Faction Philosophy System
+
+This module defines AI personalities for each faction in Warfare. Profiles
+influence node designation, resource goals and diplomatic behavior.
+
+```lua
+local phil = require 'gamma_walo.gamedata.scripts.faction_philosophy'
+print(phil.get_faction_aggression('duty')) -- 0.9
+```
+
+## Profiles
+
+- **Duty** – favors weapons and armor, shuns herbs. Highly aggressive with
+  limited diplomacy.
+- **Freedom** – values herbs and electronics. Balanced aggression and diplomacy.
+- **Monolith** – relentless zealots ignoring science and medicine. Max aggression
+  and minimal diplomacy.
+- **Ecologists** – focus on science and research resources. Pacifistic and open
+  to diplomacy.
+- **Clear Sky** – mixes science and armor priorities. Generally cooperative.
+- **Mercenaries** – pursue profit via weapons and tech. Aggressive negotiators.
+- **Bandits** – prioritize loot and artifacts, ignoring scientific needs.
+- **Loners (Stalkers)** – adaptable scavengers with average aggression.
+- **Renegades** – rough raiders ignoring high-tech gear.
+- **Sin** – fanatic artifact hunters hostile to diplomacy.
+- **UNISG** – elite operatives seeking scientific artifacts.

--- a/gamma_walo/gamedata/scripts/faction_philosophy.script
+++ b/gamma_walo/gamedata/scripts/faction_philosophy.script
@@ -1,0 +1,119 @@
+--[[
+    faction_philosophy.script
+    -------------------------
+    Personality profiles for Warfare AI factions. Each profile defines
+    resource priorities, aggression level and diplomacy tendency. Other
+    systems reference this to bias their decisions.
+]]
+
+local philosophy = {
+    data = {
+        duty = {
+            priority = { "weapons", "armor", "medicine" },
+            ignores  = { "herbs" },
+            aggression = 0.9,
+            diplomacy = 0.4
+        },
+        freedom = {
+            priority = { "herbs", "weapons", "electronics" },
+            aggression = 0.6,
+            diplomacy = 0.7
+        },
+        monolith = {
+            priority = { "armor", "weapons" },
+            ignores  = { "science", "medicine" },
+            aggression = 1.0,
+            diplomacy = 0.1
+        },
+        ecologists = {
+            priority = { "science", "electronics", "herbs" },
+            ignores  = { "armor" },
+            aggression = 0.1,
+            diplomacy = 0.9
+        },
+        clear_sky = {
+            priority = { "herbs", "science", "armor" },
+            aggression = 0.3,
+            diplomacy = 0.8
+        },
+        mercenaries = {
+            priority = { "weapons", "electronics", "armor" },
+            ignores  = {},
+            aggression = 0.8,
+            diplomacy = 0.3
+        },
+        bandits = {
+            priority = { "weapons", "scrap", "artifacts" },
+            ignores  = { "science", "electronics" },
+            aggression = 0.7,
+            diplomacy = 0.2
+        },
+        stalker = {
+            priority = { "weapons", "artifacts", "armor" },
+            aggression = 0.5,
+            diplomacy = 0.6
+        },
+        renegades = {
+            priority = { "scrap", "weapons" },
+            ignores  = { "science", "electronics" },
+            aggression = 0.75,
+            diplomacy = 0.2
+        },
+        sin = {
+            priority = { "artifacts" },
+            ignores  = { "science", "electronics", "medicine" },
+            aggression = 0.95,
+            diplomacy = 0.1
+        },
+        unisg = {
+            priority = { "science", "electronics", "artifacts" },
+            aggression = 0.85,
+            diplomacy = 0.3
+        }
+    }
+}
+
+-- default fallback values
+local default_profile = { priority = {}, ignores = {}, aggression = 0.5, diplomacy = 0.5 }
+
+--- Internal helper: get profile table or default
+local function get_profile(id)
+    if type(id) ~= "string" then return default_profile end
+    return philosophy.data[id] or default_profile
+end
+
+--- Get prioritized resource list for a faction.
+-- @param faction_id string
+-- @return table list of resource names
+function philosophy.get_faction_priorities(faction_id)
+    return get_profile(faction_id).priority
+end
+
+--- Get aggression value for a faction.
+-- @param faction_id string
+-- @return number between 0 and 1
+function philosophy.get_faction_aggression(faction_id)
+    return get_profile(faction_id).aggression
+end
+
+--- Get diplomacy level for a faction.
+-- @param faction_id string
+-- @return number between 0 and 1
+function philosophy.get_faction_diplomacy_level(faction_id)
+    return get_profile(faction_id).diplomacy
+end
+
+--- Check if a resource is ignored by a faction.
+-- @param faction_id string
+-- @param resource string
+-- @return boolean
+function philosophy.is_resource_ignored(faction_id, resource)
+    local prof = get_profile(faction_id)
+    if not resource or type(resource) ~= "string" then return false end
+    for _, r in ipairs(prof.ignores) do
+        if r == resource then return true end
+    end
+    return false
+end
+
+return philosophy

--- a/tests/faction_philosophy_spec.lua
+++ b/tests/faction_philosophy_spec.lua
@@ -1,0 +1,2 @@
+local env = _ENV
+assert(loadfile('tests/faction_philosophy_spec.script', 't', env))()

--- a/tests/faction_philosophy_spec.script
+++ b/tests/faction_philosophy_spec.script
@@ -1,0 +1,33 @@
+_G.printf = function() end
+local phil = dofile('gamma_walo/gamedata/scripts/faction_philosophy.script')
+
+describe('faction_philosophy', function()
+    it('contains all faction profiles', function()
+        local factions = {
+            'duty','freedom','monolith','ecologists','clear_sky',
+            'mercenaries','bandits','stalker','renegades','sin','unisg'
+        }
+        for _, f in ipairs(factions) do
+            assert.is.table(phil.data[f])
+        end
+    end)
+
+    it('priorities are tables', function()
+        for _, prof in pairs(phil.data) do
+            assert.is.table(prof.priority)
+        end
+    end)
+
+    it('aggression and diplomacy within bounds', function()
+        for _, prof in pairs(phil.data) do
+            assert.is_true(prof.aggression >= 0 and prof.aggression <= 1)
+            assert.is_true(prof.diplomacy >= 0 and prof.diplomacy <= 1)
+        end
+    end)
+
+    it('honors ignore lists', function()
+        assert.is_true(phil.is_resource_ignored('duty', 'herbs'))
+        assert.is_false(phil.is_resource_ignored('duty', 'weapons'))
+        assert.is_false(phil.is_resource_ignored('unknown', 'scrap'))
+    end)
+end)


### PR DESCRIPTION
## Summary
- implement `faction_philosophy.script` with per-faction profiles
- document usage in `docs/faction_philosophy.md`
- add unit tests validating the system

## Testing
- `busted tests`

------
https://chatgpt.com/codex/tasks/task_e_68821e094a38832e9819b9d027abf875