### PR TITLE
Add faction collapse tracking system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,4 @@ All notable changes to this project will be documented in this file.
 - Integrated resource nodes with base and spawn logic; added daily production tick.
 
 - Added daily_sim_engine with daily cycle logic and new tests.
+- Added faction_state system tracking HQs and collapse.

--- a/docs/api_map.md
+++ b/docs/api_map.md
@@ -9,7 +9,7 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 - `base_logic.needs` (line 62)
 
 ## daily_sim_engine.script
-- `daily.run_day` (line 21)
+- `daily.run_day` (line 22)
 
 ## dialogs.script
 - `can_do_task_mysteries_of_the_zone` (line 14)
@@ -336,6 +336,12 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 - `philosophy.get_faction_diplomacy_level` (line 102)
 - `philosophy.is_resource_ignored` (line 110)
 
+## faction_state.script
+- `state.register_hq` (line 19)
+- `state.remove_hq` (line 28)
+- `state.is_collapsed` (line 39)
+- `state.evaluate_all` (line 44)
+
 ## game_fast_travel.script
 - `allow_local_logging` (line 44)
 - `set_debug_logging` (line 55)
@@ -479,15 +485,16 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 - `monolith.select_target` (line 11)
 
 ## node_system.script
-- `node_system.register_node` (line 31)
-- `node_system.capture_node` (line 38)
-- `node_system.establish_node` (line 49)
-- `node_system.specialize_node` (line 65)
-- `node_system.upgrade_node` (line 85)
-- `node_system.tick_production` (line 94)
-- `node_system.get_node` (line 109)
-- `node_system.get_node_type` (line 115)
-- `node_system.get_node_specialization` (line 123)
+- `node_system.register_node` (line 32)
+- `node_system.capture_node` (line 39)
+- `node_system.establish_node` (line 53)
+- `node_system.specialize_node` (line 69)
+- `node_system.upgrade_node` (line 92)
+- `node_system.abandon_node` (line 102)
+- `node_system.tick_production` (line 117)
+- `node_system.get_node` (line 132)
+- `node_system.get_node_type` (line 138)
+- `node_system.get_node_specialization` (line 146)
 
 ## pda_context_menu.script
 - `menu.get_options` (line 11)

--- a/docs/runtime_vs_gamma_walo.md
+++ b/docs/runtime_vs_gamma_walo.md
@@ -960,6 +960,7 @@ This report compares scripts in `runtime files/gamedata/scripts` against their c
 | diplomacy_system.script | new file | - | new module |
 | faction_ai_logic.script | new file | - | new module |
 | faction_philosophy.script | new file | - | new module |
+| faction_state.script | new file | - | new module |
 | hq_coordinator.script | new file | - | new module |
 | legendary_squad_system.script | new file | - | new module |
 | meta_overlord.script | new file | - | new module |

--- a/gamma_walo/gamedata/scripts/daily_sim_engine.script
+++ b/gamma_walo/gamedata/scripts/daily_sim_engine.script
@@ -4,7 +4,7 @@
     Runs the daily simulation cycle for Warfare overhaul. This ties together
     resource production, base consumption, transport task generation and squad
     spawning. Called once per in-game day by an external scheduler.
-    Last edit: 2025-07-25
+    Last edit: 2025-07-26
 ]]
 
 local node_system  = require 'node_system'
@@ -14,6 +14,7 @@ local base_logic    = require 'base_node_logic'
 local coordinator   = require 'hq_coordinator'
 local spawn_system  = require 'squad_spawn_system'
 local diplomacy     = require 'diplomacy_core'
+local faction_state = require 'faction_state'
 
 local daily = {}
 
@@ -39,6 +40,8 @@ function daily.run_day()
         end
         diplomacy.evaluate(faction, resource_pool)
     end
+
+    faction_state.evaluate_all()
 end
 
 return daily

--- a/gamma_walo/gamedata/scripts/faction_state.script
+++ b/gamma_walo/gamedata/scripts/faction_state.script
@@ -1,0 +1,52 @@
+--[[
+    faction_state.script
+    --------------------
+    Tracks faction HQ presence and collapse state. HQ nodes must exist for a
+    faction to remain stable. Called by node_system when HQ nodes are
+    specialized, captured or destroyed. Collapse flags are consulted by
+    diplomacy and AI layers.
+    Last edit: 2025-07-26
+]]
+
+local state = {
+    hqs = {},        -- [faction] = { [node_id]=true }
+    collapsed = {}   -- [faction] = true if faction has no HQs
+}
+
+--- Register an HQ node for a faction.
+-- @param node_id string
+-- @param faction string
+function state.register_hq(node_id, faction)
+    state.hqs[faction] = state.hqs[faction] or {}
+    state.hqs[faction][node_id] = true
+    state.collapsed[faction] = nil
+end
+
+--- Remove an HQ node from tracking.
+-- @param node_id string
+-- @param faction string
+function state.remove_hq(node_id, faction)
+    local tbl = state.hqs[faction]
+    if tbl then
+        tbl[node_id] = nil
+        if next(tbl) == nil then
+            state.collapsed[faction] = true
+        end
+    end
+end
+
+--- Check if a faction has collapsed.
+function state.is_collapsed(faction)
+    return state.collapsed[faction] == true
+end
+
+--- Validate all factions, marking collapsed ones without HQs.
+function state.evaluate_all()
+    for f, nodes in pairs(state.hqs) do
+        if not nodes or next(nodes) == nil then
+            state.collapsed[f] = true
+        end
+    end
+end
+
+return state

--- a/gamma_walo/gamedata/scripts/node_system.script
+++ b/gamma_walo/gamedata/scripts/node_system.script
@@ -16,6 +16,7 @@ local node_system = {
 
 local base_logic = require("base_node_logic")
 local resource_sys = require("resource_system")
+local faction_state = require("faction_state")
 
 -- internal helper to fire global hooks safely
 local function call_hook(name, ...)
@@ -38,6 +39,9 @@ end
 function node_system.capture_node(id, faction)
     local node = node_system.nodes[id]
     if not node then return end
+    if node.specialization == 'hq' and node.owner and node.owner ~= faction then
+        faction_state.remove_hq(id, node.owner)
+    end
     node.owner = faction
     printf("[node_system] %s captured by %s", id, faction)
     call_hook("on_node_captured", id, faction)
@@ -70,6 +74,9 @@ function node_system.specialize_node(id, spec)
         if base_logic and type(base_logic.register_base) == "function" then
             base_logic.register_base(id, node.owner, spec)
         end
+        if spec == 'hq' then
+            faction_state.register_hq(id, node.owner)
+        end
     elseif node.state == node_system.STATE.resource then
         if resource_sys and type(resource_sys.capture_node) == "function" then
             resource_sys.capture_node(id, node.owner, spec, 0)
@@ -87,6 +94,22 @@ function node_system.upgrade_node(id)
     if not node then return end
     node.level = (node.level or 1) + 1
     printf("[node_system] %s upgraded to %d", id, node.level)
+end
+
+--- Abandon a node, clearing owner and specialization.
+--  Removes HQ tracking when needed.
+-- @param id string Node identifier
+function node_system.abandon_node(id)
+    local node = node_system.nodes[id]
+    if not node then return end
+    if node.specialization == 'hq' and node.owner then
+        faction_state.remove_hq(id, node.owner)
+    end
+    node.owner = nil
+    node.specialization = nil
+    node.state = node_system.STATE.territory
+    node.level = 1
+    printf("[node_system] %s abandoned", id)
 end
 
 --- Produce resources for all specialized nodes.

--- a/tests/faction_state_spec.lua
+++ b/tests/faction_state_spec.lua
@@ -1,0 +1,21 @@
+require('tests.spec_helper')
+local node = require('node_system')
+local state = require('faction_state')
+
+describe('faction_state', function()
+    before_each(function()
+        node.nodes = {}
+        state.hqs = {}
+        state.collapsed = {}
+    end)
+
+    it('collapses faction when last hq removed', function()
+        node.register_node('h1')
+        node.capture_node('h1', 'duty')
+        node.establish_node('h1', node.STATE.base)
+        node.specialize_node('h1', 'hq')
+        assert.is_false(state.is_collapsed('duty'))
+        node.abandon_node('h1')
+        assert.is_true(state.is_collapsed('duty'))
+    end)
+end)


### PR DESCRIPTION
## Summary
- implement `faction_state.script` to monitor HQ nodes and collapse factions when none remain
- integrate faction collapse with node_system and daily_sim_engine
- add abandon_node support for removing HQs
- document new APIs and regenerate docs
- test faction collapse behaviour

## Testing
- `busted tests`


------
https://chatgpt.com/codex/tasks/task_e_68827e96def4832ea14ed37713335ffb