### PR TITLE
Subtask: Enhance HQ Logistics Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,4 @@ All notable changes to this project will be documented in this file.
 
 - Added daily_sim_engine with daily cycle logic and new tests.
 - Added faction_state system tracking HQs and collapse.
+\n- Added HQ logistics upgrade prioritization logic and base upgrade tests.

--- a/agent_subtasks.md
+++ b/agent_subtasks.md
@@ -18,7 +18,7 @@ Update resource_system.script to adjust daily output based on level
 
 Add PDA interaction stub (UI to upgrade node)
 
-[ ] Enhance HQ Logistics Commands
+[x] Enhance HQ Logistics Commands
 
 Allow HQ to prioritize base upgrades based on stockpile delta
 

--- a/docs/api_map.md
+++ b/docs/api_map.md
@@ -3,10 +3,13 @@
 This index lists public functions defined in the `gamma_walo/gamedata/scripts` directory.
 
 ## base_node_logic.script
-- `base_logic.register_base` (line 33)
-- `base_logic.add_resource` (line 41)
-- `base_logic.consume` (line 47)
-- `base_logic.needs` (line 62)
+- `base_logic.register_base` (line 37)
+- `base_logic.add_resource` (line 45)
+- `base_logic.consume` (line 51)
+- `base_logic.needs` (line 66)
+- `base_logic.stockpile_delta` (line 74)
+- `base_logic.can_upgrade` (line 85)
+- `base_logic.consume_upgrade_cost` (line 91)
 
 ## daily_sim_engine.script
 - `daily.run_day` (line 22)
@@ -469,8 +472,8 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 - `get_reputation_relation` (line 943)
 
 ## hq_coordinator.script
-- `coordinator.register_base` (line 19)
-- `coordinator.evaluate` (line 25)
+- `coordinator.register_base` (line 22)
+- `coordinator.evaluate` (line 28)
 
 ## legendary_squad_system.script
 - `legendary.add_experience` (line 25)

--- a/gamma_walo/gamedata/scripts/base_node_logic.script
+++ b/gamma_walo/gamedata/scripts/base_node_logic.script
@@ -3,8 +3,9 @@
     ----------------------
     Maintains per-base stockpiles and consumption logic. Each base node
     stores resources up to 10 units per type. Daily consumption is
-    determined by base specialization.
-    Last edit: 2025-07-25
+    determined by base specialization. Also exposes upgrade helpers used
+    by HQ logistics to decide when to invest resources.
+    Last edit: 2025-07-30
 ]]
 
 local base_logic = {
@@ -14,7 +15,10 @@ local base_logic = {
         trader  = {scrap=1, electronics=1, artifacts=1},
         research= {electronics=1, herbs=1, artifacts=1},
         hq      = {}
-    }
+    },
+
+    -- cost to upgrade a base one level
+    UPGRADE_COST = {scrap=5, electronics=5}
 }
 
 --- Ensure a base record exists.
@@ -62,6 +66,33 @@ end
 function base_logic.needs(id, rtype)
     local b = get_base(id)
     return (b.stockpile[rtype] or 0) < 10
+end
+
+--- Calculate how many resources a base still requires to upgrade.
+-- @param id string Base identifier
+-- @return number delta Sum of missing resources
+function base_logic.stockpile_delta(id)
+    local b = get_base(id)
+    local delta = 0
+    for r, amt in pairs(base_logic.UPGRADE_COST) do
+        delta = delta + math.max(0, amt - (b.stockpile[r] or 0))
+    end
+    return delta
+end
+
+--- Determine if a base can pay for an upgrade.
+-- @param id string Base identifier
+function base_logic.can_upgrade(id)
+    return base_logic.stockpile_delta(id) == 0
+end
+
+--- Deduct upgrade resources from a base stockpile.
+-- Safe to call only after `can_upgrade`.
+function base_logic.consume_upgrade_cost(id)
+    local b = get_base(id)
+    for r, amt in pairs(base_logic.UPGRADE_COST) do
+        b.stockpile[r] = (b.stockpile[r] or 0) - amt
+    end
 end
 
 return base_logic

--- a/gamma_walo/gamedata/scripts/hq_coordinator.script
+++ b/gamma_walo/gamedata/scripts/hq_coordinator.script
@@ -3,12 +3,15 @@
     ---------------------
     Oversees faction logistics and squad spawning. Bases register
     themselves with the coordinator which periodically checks for
-    low stockpiles and schedules transports.
-    Last edit: 2025-07-25
+    low stockpiles and schedules transports. It now also evaluates
+    potential base upgrades based on stored resources and queues
+    higher-priority supply runs when close to requirements.
+    Last edit: 2025-07-30
 ]]
 
 local node_logic = require 'base_node_logic'
 local resource = require 'resource_system'
+local node_system = require 'node_system'
 
 local coordinator = {
     tasks = {}, -- queued transport tasks
@@ -24,6 +27,8 @@ end
 --- Schedule transports for under-supplied bases.
 function coordinator.evaluate(faction)
     local bases = coordinator.bases_by_faction[faction] or {}
+    local upgrade_target
+    local upgrade_delta = math.huge
     for _, id in ipairs(bases) do
         local base = node_logic.bases[id]
         for r, _ in pairs(node_logic.CONSUMPTION[base.type] or {}) do
@@ -31,6 +36,31 @@ function coordinator.evaluate(faction)
                 local node_id = resource.find_node_with_resource(faction, r)
                 if node_id then
                     table.insert(coordinator.tasks, {from=node_id, to=id, resource=r, amount=1})
+                end
+            end
+        end
+
+        -- track base closest to upgrade requirements
+        local delta = node_logic.stockpile_delta(id)
+        if delta < upgrade_delta then
+            upgrade_target = id
+            upgrade_delta = delta
+        end
+    end
+
+    -- prioritize upgrading the base nearest completion
+    if upgrade_target and upgrade_delta <= 2 then
+        if node_logic.can_upgrade(upgrade_target) then
+            node_logic.consume_upgrade_cost(upgrade_target)
+            node_system.upgrade_node(upgrade_target)
+        else
+            for res_type, need in pairs(node_logic.UPGRADE_COST) do
+                local missing = need - (node_logic.bases[upgrade_target].stockpile[res_type] or 0)
+                if missing > 0 then
+                    local node_id = resource.find_node_with_resource(faction, res_type)
+                    if node_id then
+                        table.insert(coordinator.tasks, 1, {from=node_id, to=upgrade_target, resource=res_type, amount=missing})
+                    end
                 end
             end
         end

--- a/tests/hq_coordinator_spec.lua
+++ b/tests/hq_coordinator_spec.lua
@@ -2,6 +2,7 @@ _G.printf = function() end
 package.path = 'gamma_walo/gamedata/scripts/?.script;' .. package.path
 local base = require('base_node_logic')
 local res  = require('resource_system')
+local node = require('node_system')
 local hq   = require('hq_coordinator')
 
 describe('hq_coordinator', function()
@@ -20,5 +21,19 @@ describe('hq_coordinator', function()
         hq.evaluate('duty')
         assert.equals(1, #hq.tasks)
         assert.equals('n1', hq.tasks[1].from)
+    end)
+
+    it('upgrades bases when requirements met', function()
+        node.nodes = {}
+        node.register_node('b1')
+        node.capture_node('b1','duty')
+        node.establish_node('b1', node.STATE.base)
+        node.specialize_node('b1', 'militia')
+        base.register_base('b1','duty','militia')
+        base.add_resource('b1','scrap',5)
+        base.add_resource('b1','electronics',5)
+        hq.register_base('duty','b1')
+        hq.evaluate('duty')
+        assert.equals(2, node.nodes['b1'].level)
     end)
 end)


### PR DESCRIPTION
## Summary
- expand `base_node_logic` with upgrade costs and helper functions
- prioritize base upgrades in `hq_coordinator` evaluation
- add unit test for upgrade behavior
- mark subtask as complete and regenerate docs

## Testing
- `busted tests`


------
https://chatgpt.com/codex/tasks/task_e_6882ac6546a4832e80f8c46c41256733