### PR TITLE
Subtask: Add Dynamic Rerouting Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,4 @@ All notable changes to this project will be documented in this file.
 
 - Final integration verification completed. Generated docs/final_integration_report.md for Pass 5.
 - Implemented transport squad loot recovery system and tests.
+- Added dynamic transport rerouting when members die or danger detected.

--- a/agent_subtasks.md
+++ b/agent_subtasks.md
@@ -75,7 +75,7 @@ This document defines specific, scoped tasks for Codex agents to implement in or
   - Patrol squads that pass the body should collect dropped resources.  
   - 🔗 Must tie into **existing death and loot callbacks** in GAMMA.  
 
-- [ ] **Add Dynamic Rerouting Logic**  
+- [x] **Add Dynamic Rerouting Logic**
   - Reroute transports on death or danger.  
   - Integrate reroute logic into `squad_transport.script`.  
   - Ensure reroutes respect GAMMA faction and AI task systems.  

--- a/diff_summary.json
+++ b/diff_summary.json
@@ -118,9 +118,16 @@
     ]
   },
   "hq_coordinator.script": {
-    "added": [],
+    "added": [
+      "coordinator.get_fallback_base"
+    ],
     "removed": [],
-    "modified": []
+    "modified": [
+      {
+        "name": "coordinator.register_base",
+        "diff_lines": 8
+      }
+    ]
   },
   "legendary_squad_system.script": {
     "added": [],
@@ -214,12 +221,19 @@
     "modified": []
   },
   "squad_transport.script": {
-    "added": [],
+    "added": [
+      "transport.reroute",
+      "transport.mark_danger"
+    ],
     "removed": [],
     "modified": [
       {
         "name": "transport.create",
-        "diff_lines": 10
+        "diff_lines": 15
+      },
+      {
+        "name": "transport.drop_cargo",
+        "diff_lines": 23
       }
     ]
   },

--- a/docs/api_map.md
+++ b/docs/api_map.md
@@ -473,7 +473,8 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 
 ## hq_coordinator.script
 - `coordinator.register_base` (line 22)
-- `coordinator.evaluate` (line 28)
+- `coordinator.get_fallback_base` (line 28)
+- `coordinator.evaluate` (line 39)
 
 ## legendary_squad_system.script
 - `legendary.add_experience` (line 25)
@@ -667,8 +668,8 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 - `scaler.apply_loadout` (line 20)
 
 ## squad_loot_recovery.script
-- `recovery.on_npc_death` (line 19)
-- `recovery.collect_nearby_loot` (line 27)
+- `recovery.on_npc_death` (line 20)
+- `recovery.collect_nearby_loot` (line 31)
 
 ## squad_spawn_system.script
 - `spawn_system.can_spawn_squad` (line 15)
@@ -676,8 +677,10 @@ This index lists public functions defined in the `gamma_walo/gamedata/scripts` d
 - `spawn_system.spawn_squad` (line 40)
 
 ## squad_transport.script
-- `transport.create` (line 13)
-- `transport.drop_cargo` (line 23)
+- `transport.create` (line 15)
+- `transport.drop_cargo` (line 27)
+- `transport.reroute` (line 50)
+- `transport.mark_danger` (line 61)
 
 ## tasks_assault.script
 - `is_legit_mutant_squad` (line 79)

--- a/gamma_walo/gamedata/scripts/hq_coordinator.script
+++ b/gamma_walo/gamedata/scripts/hq_coordinator.script
@@ -24,6 +24,17 @@ function coordinator.register_base(faction, base_id)
     table.insert(coordinator.bases_by_faction[faction], base_id)
 end
 
+--- Return an alternate base for fallback logistics.
+function coordinator.get_fallback_base(faction, exclude)
+    local bases = coordinator.bases_by_faction[faction] or {}
+    for _, id in ipairs(bases) do
+        if id ~= exclude then
+            return id
+        end
+    end
+    return nil
+end
+
 --- Schedule transports for under-supplied bases.
 function coordinator.evaluate(faction)
     local bases = coordinator.bases_by_faction[faction] or {}

--- a/gamma_walo/gamedata/scripts/squad_loot_recovery.script
+++ b/gamma_walo/gamedata/scripts/squad_loot_recovery.script
@@ -9,6 +9,7 @@
 
 local recovery = { dropped = {} }
 local resource_sys = require 'resource_system'
+local transport = require 'squad_transport'
 
 local function distance(a,b)
     local dx=a.x-b.x; local dy=a.y-b.y; local dz=a.z-b.z
@@ -21,6 +22,9 @@ function recovery.on_npc_death(victim, killer)
     local pos = victim.position or {x=0,y=0,z=0}
     table.insert(recovery.dropped, {resource=victim.carrying, position=pos})
     victim.carrying = nil
+    if victim.squad then
+        transport.mark_danger(victim.squad)
+    end
 end
 
 --- Patrol squads call to collect nearby loot.

--- a/gamma_walo/gamedata/scripts/squad_transport.script
+++ b/gamma_walo/gamedata/scripts/squad_transport.script
@@ -8,13 +8,17 @@
 ]]
 
 local transport = {}
+local hq_module = require 'hq_coordinator'
+transport.hq = hq_module
 
 --- Create a transport descriptor from a HQ task.
 function transport.create(task)
-    local squad = {from=task.from, to=task.to, resource=task.resource, cargo=task.amount, members={}}
+    local squad = {from=task.from, to=task.to, faction=task.faction, resource=task.resource, cargo=task.amount, members={}}
     for i=1, task.amount do
         -- each member stores carried resource for loot recovery
-        table.insert(squad.members, {carrying=task.resource})
+        local mem = {carrying=task.resource}
+        mem.squad = squad
+        table.insert(squad.members, mem)
     end
     return squad
 end
@@ -25,6 +29,37 @@ function transport.drop_cargo(squad)
     squad.cargo = 0
     squad.members = {}
     return dropped
+end
+
+--- Choose an alternate base destination for the squad.
+local function pick_fallback_base(faction, exclude)
+    local hq = transport.hq or hq_module
+    if hq.get_fallback_base then
+        return hq.get_fallback_base(faction, exclude)
+    end
+    local bases = hq.bases_by_faction[faction] or {}
+    for _, id in ipairs(bases) do
+        if id ~= exclude then
+            return id
+        end
+    end
+    return nil
+end
+
+--- Reroute a transport squad to a safe base.
+function transport.reroute(squad)
+    if not squad or not squad.faction then return end
+    local new_to = pick_fallback_base(squad.faction, squad.to)
+    if new_to then
+        squad.to = new_to
+        return true
+    end
+    return false
+end
+
+--- Mark squad in danger and trigger reroute.
+function transport.mark_danger(squad)
+    return transport.reroute(squad)
 end
 
 return transport

--- a/prescope.md
+++ b/prescope.md
@@ -135,3 +135,28 @@ Capture transport squad cargo when members die and allow patrol squads to retrie
 - Documentation regenerated and diff summary updated.
 - Checklist updated in `agent_subtasks.md`.
 
+## Task: Add Dynamic Rerouting Logic
+
+### Objective
+Allow transport squads to dynamically reroute to a different base when squad members die or when an external danger flag is raised.
+
+### Steps
+1. Extend `squad_transport.script` with a new `reroute(squad)` function that selects a fallback base using `hq_coordinator.bases_by_faction`.
+2. Update `transport.create` to store `faction` on the squad and reference the squad in each member table for callback usage.
+3. Expose `mark_danger(squad)` which simply calls `reroute`.
+4. Modify `squad_loot_recovery.on_npc_death` to reroute the victim's squad when available.
+5. Add helper `get_fallback_base(faction, exclude)` to `hq_coordinator.script`.
+6. Write new unit tests in `squad_transport_spec.lua` validating reroute behaviour.
+7. Regenerate documentation via `tools/gen_docs.py` and `tools/generate_diff_summary.py`.
+8. Run `busted tests` to ensure suite passes.
+9. Update `CHANGELOG.md` and mark subtask complete in `agent_subtasks.md`.
+
+### Integration Points
+- Rerouting relies on HQ coordinator base lists from existing logistics system.
+- Loot death callback in `squad_loot_recovery` triggers reroute using new API.
+
+### Completion Criteria
+- Reroute logic implemented with tests.
+- Documentation and diff summary updated.
+- Subtask checkbox ticked in `agent_subtasks.md`.
+

--- a/tests/squad_loot_recovery_spec.lua
+++ b/tests/squad_loot_recovery_spec.lua
@@ -1,6 +1,7 @@
 package.path = 'gamma_walo/gamedata/scripts/?.script;' .. package.path
 local recovery = require('squad_loot_recovery')
 local resource = require('resource_system')
+local transport = require('squad_transport')
 
 describe('squad_loot_recovery', function()
     before_each(function()
@@ -25,5 +26,13 @@ describe('squad_loot_recovery', function()
 
         assert.equals(1, resource.get_resource('duty', 'electronics'))
         assert.equals(0, #recovery.dropped)
+    end)
+
+    it('reroutes transport on member death', function()
+        transport.hq = {bases_by_faction={duty={'b1','b2'}}}
+        local sq = transport.create{from='n1', to='b1', faction='duty', resource='scrap', amount=1}
+        local npc = sq.members[1]
+        recovery.on_npc_death(npc, nil)
+        assert.equals('b2', sq.to)
     end)
 end)

--- a/tests/squad_transport_spec.lua
+++ b/tests/squad_transport_spec.lua
@@ -14,4 +14,11 @@ describe('squad_transport', function()
         assert.equals(2, drop)
         assert.equals(0, sq.cargo)
     end)
+
+    it('reroutes to alternate base on danger', function()
+        transport.hq = {bases_by_faction = {duty={'b1','b2'}}}
+        local sq = transport.create{from='n1', to='b1', faction='duty', resource='scrap', amount=2}
+        transport.mark_danger(sq)
+        assert.equals('b2', sq.to)
+    end)
 end)


### PR DESCRIPTION
## Summary
- implement dynamic rerouting in `squad_transport` and tie into `squad_loot_recovery`
- expose fallback base helper in `hq_coordinator`
- regenerate docs and diff summaries
- add unit tests for rerouting behaviour
- update prescope plan and mark subtask complete

## Testing
- `python tools/generate_diff_summary.py`
- `python tools/gen_docs.py`
- `busted tests`

------
https://chatgpt.com/codex/tasks/task_e_6883c43f6aa4832e8ab6a3f215cdec66