### PR TITLE
Port WALO dialogs helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Documented completion of old_walo conflict summary task.
 - Updated conflict summary with notes about `gammas patch` script differences.
 - Planned merge strategy per WALO file documented in `docs/walo_merge_strategy.md`.
+- Ported WALO dialog helper and important document rewards into `dialogs.script` and added tests.

--- a/DevDiary.md
+++ b/DevDiary.md
@@ -155,3 +155,37 @@ Added bullet for `ui_mm_faction_select.script` noting no functional differences.
 
 ### Implementation Notes
 Will create new Markdown file summarizing planned approach for every `old_walo` and `gammas patch` script. This completes the planning stage before actual code merges.
+
+## Prescope: Port dialogs.script helper and important_docs table
+- **Task ID**: WALO port – Port dialogs.script helper and important_docs table
+- **Agent**: ResourceInfrastructureAgent (assuming generic dev agent)
+- **Summary**: Integrate `warfare_disabled` dialog helper and the `important_docs` reward table from old WALO. Ensures tasks and document rewards behave as expected in warfare mode.
+
+### Scope & Context
+- Affected file: `gamma_walo/gamedata/scripts/dialogs.script`
+- Engine hooks: dialog conditions via `warfare_disabled`; trade reward functions.
+
+### Dependencies
+- None. This file is independent of other WALO merges.
+
+### Data Flow Analysis
+- Input: dialog preconditions call `warfare_disabled`; trade functions reference `important_docs` table.
+- Output: returns boolean for dialog options; reward values for documents.
+- Downstream: quest dialogs and trade interactions.
+
+### Failure Cases
+- Missing table entries could break main storyline rewards.
+- Incorrect helper logic may hide dialog options incorrectly.
+
+### Test Plan
+- Unit test: call `warfare_disabled` with `_G.WARFARE` both true and false.
+- Unit test: ensure `important_docs` contains expected keys.
+
+### Rollback & Risk
+- Low risk: revert file if issues arise.
+
+
+## Implementation: Port dialogs.script helper and important_docs table
+- Added detailed comments for `warfare_disabled` helper.
+- Restored important document reward values from old WALO.
+- Created Busted tests covering helper logic and table presence.

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -1,1 +1,10 @@
 [a] WALO port
+[x] Port dialogs.script helper and important_docs table (weight: 300)
+[ ] Apply spawn chance formulas to faction_expansions.script (weight: 250)
+[ ] Optimize relation loops in game_relations.script (weight: 250)
+[ ] Harden sim_offline_combat loops (weight: 200)
+[ ] Add nil checks to smart_terrain_warfare.script (weight: 150)
+[ ] Merge tasks_assault stability fixes (weight: 150)
+[ ] Merge tasks_smart_control stability fixes (weight: 100)
+[ ] Integrate warfare options into ui_options.script (weight: 200)
+[ ] Review remaining WALO scripts for minor changes (weight: 100)

--- a/gamma_walo/gamedata/scripts/dialogs.script
+++ b/gamma_walo/gamedata/scripts/dialogs.script
@@ -32,12 +32,17 @@ function give_task_mysteries_of_the_zone(a,b)
 	task_manager.get_task_manager():give_task("mar_find_doctor_task")
 end
 
--- Helper used in dialog preconditions to hide options when Warfare is active
-function warfare_disabled(a,b)
-	if _G.WARFARE then
-		return false
-	end
-	return true
+--[[
+        Check if Warfare is disabled.
+        @param a Unused dialog actor
+        @param b Unused dialog npc
+        @return boolean True if Warfare mode is not active
+]]
+function warfare_disabled(a, b)
+       if _G.WARFARE then
+               return false
+       end
+       return true
 end
 
 -------------------------------------------
@@ -2469,7 +2474,16 @@ end
 -----------------------------------------------------------------------------------
 -- Trade important documents
 -----------------------------------------------------------------------------------
+-- Table of quest document sections and their base sell prices
+-- pulled from old WALO to keep storyline rewards consistent
 local important_docs = {
+       ["main_story_1_quest_case"] = 10000,
+       ["main_story_2_lab_x18_documents"] = 13000,
+       ["main_story_3_lab_x16_documents"] = 16000,
+       ["main_story_4_lab_x10_documents"] = 20000,
+       ["main_story_5_lab_x8_documents"] = 13000,
+       ["main_story_6_jup_ug_documents"] = 14000,
+       ["main_story_7_mon_con_documents"] = 25000,
 }
 
 local important_docs_warfare_names = {

--- a/tests/dialogs_spec.lua
+++ b/tests/dialogs_spec.lua
@@ -1,0 +1,27 @@
+local file = assert(io.open('gamma_walo/gamedata/scripts/dialogs.script'))
+local content = file:read('*all')
+file:close()
+
+-- load script in global environment
+package.path = package.path .. ';gamma_walo/gamedata/scripts/?.script'
+dofile('gamma_walo/gamedata/scripts/dialogs.script')
+
+
+describe('dialogs.warfare_disabled', function()
+    it('returns false when warfare active', function()
+        _G.WARFARE = true
+        assert.is_false(warfare_disabled(nil, nil))
+    end)
+
+    it('returns true when warfare inactive', function()
+        _G.WARFARE = nil
+        assert.is_true(warfare_disabled(nil, nil))
+    end)
+end)
+
+describe('important_docs table', function()
+    it('contains main quest document entries', function()
+        assert.is_truthy(content:find('main_story_1_quest_case'))
+        assert.is_truthy(content:find('main_story_7_mon_con_documents'))
+    end)
+end)


### PR DESCRIPTION
## Summary
- port `warfare_disabled` helper and document rewards from old WALO
- add tests for warfare_disabled behaviour and document list
- record implementation notes in DevDiary and update changelog
- start subtasks for remaining WALO ports

## Testing
- `busted tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6884cba59f60832e879cdb17e664cf0b