### PR TITLE
Add tests for spawn chance formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Updated conflict summary with notes about `gammas patch` script differences.
 - Planned merge strategy per WALO file documented in `docs/walo_merge_strategy.md`.
 - Ported WALO dialog helper and important document rewards into `dialogs.script` and added tests.
+- Added tests verifying spawn chance formulas in faction_expansions.script.

--- a/DevDiary.md
+++ b/DevDiary.md
@@ -189,3 +189,31 @@ Will create new Markdown file summarizing planned approach for every `old_walo` 
 - Added detailed comments for `warfare_disabled` helper.
 - Restored important document reward values from old WALO.
 - Created Busted tests covering helper logic and table presence.
+
+## Prescope: Apply spawn chance formulas
+- **Task ID**: agent_prio - Apply spawn chance formulas to faction_expansions.script
+- **Agent**: ResourceInfrastructureAgent? Wait we are implementing integration of WALO features - which agent is responsible? According to agents.md, there is ResourceInfrastructureAgent for resource system, LogisticsAgent etc. For WALO port tasks, maybe DiffAnalysisAgent or other? No, not defined. We'll treat as DiffAnalysisAgent or general. But the tasks from 'Integration of Existing Mods' may not have dedicated agent. We'll pick DiffAnalysisAgent or some new 'Migration' agent. But we can just mention Myself as DiffAnalysisAgent since we are porting. Let's choose 'DiffAnalysisAgent'.
+- **Summary**: Ensure WALO's simplified squad spawn chance formulas are present and tested.
+### Scope & Context
+- Affects `gamma_walo/gamedata/scripts/faction_expansions.script`.
+- Functions: `get_advanced_chance`, `get_veteran_chance`.
+- Hooks: Called by squad spawn logic via `smart_terrain_warfare.script` and `warfare_factions.script`.
+### Dependencies
+- None blocking; formulas already exist in baseline.
+### Data Flow
+- Inputs: `resource` count per faction; global `warfare.resource_count`.
+- Output: numeric chance used by spawn selection.
+- Consumers: faction and smart terrain spawn routines.
+### Failure Cases
+- Incorrect formulas could skew faction balance.
+- Missing global `warfare` table may cause errors during tests.
+### Test Plan
+- Unit tests to compute chance at 0 and maximum resources.
+- Verify veteran chance scales quadratically.
+### Rollback & Risk
+- Low risk; formulas unchanged from baseline. Tests ensure correctness.
+
+## Implementation: Apply spawn chance formulas
+- Confirmed formulas already matched old WALO version.
+- Added `faction_expansions_spec.lua` tests verifying `get_advanced_chance` and `get_veteran_chance` outputs.
+

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -1,6 +1,5 @@
 [a] WALO port
 [x] Port dialogs.script helper and important_docs table (weight: 300)
-[ ] Apply spawn chance formulas to faction_expansions.script (weight: 250)
 [ ] Optimize relation loops in game_relations.script (weight: 250)
 [ ] Harden sim_offline_combat loops (weight: 200)
 [ ] Add nil checks to smart_terrain_warfare.script (weight: 150)

--- a/tests/faction_expansions_spec.lua
+++ b/tests/faction_expansions_spec.lua
@@ -1,0 +1,24 @@
+package.path = package.path .. ';gamma_walo/gamedata/scripts/?.script'
+
+-- provide minimal clsid table required by the script
+_G.clsid = setmetatable({}, { __index = function() return 0 end })
+
+-- load script into environment
+_dofile = dofile
+_dofile('gamma_walo/gamedata/scripts/faction_expansions.script')
+
+describe('faction_expansions spawn chance formulas', function()
+    before_each(function()
+        _G.warfare = { resource_count = 10 }
+    end)
+
+    it('advanced chance scales with resources', function()
+        assert.is_same(0, get_advanced_chance(0))
+        assert.is_true(math.abs(get_advanced_chance(10) - 150) < 0.001)
+    end)
+
+    it('veteran chance scales quadratically', function()
+        assert.is_same(0, get_veteran_chance(0))
+        assert.is_true(math.abs(get_veteran_chance(10) - 100) < 0.001)
+    end)
+end)


### PR DESCRIPTION
## Summary
- prescope for applying spawn chance formulas from WALO
- added tests verifying get_advanced_chance and get_veteran_chance
- documented work in DevDiary and CHANGELOG
- cleared done subtask from `agent_prio.md`

## Testing
- `busted tests`


------
https://chatgpt.com/codex/tasks/task_e_6884d50b5524832ea024216d1102ee89