### PR TITLE
Harden sim_offline_combat loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Ported WALO dialog helper and important document rewards into `dialogs.script` and added tests.
 - Added tests verifying spawn chance formulas in faction_expansions.script.
 - Optimized loops in game_relations.script based on WALO version and added unit tests for blacklist checks.
+- Hardened sim_offline_combat loops using pairs and removed SIMBOARD guard.

--- a/DevDiary.md
+++ b/DevDiary.md
@@ -223,3 +223,35 @@ Will create new Markdown file summarizing planned approach for every `old_walo` 
 - Predicted breakage: Mistyped indices may crash relation checks during gameplay
 
 - Ported blacklist loop optimisations from old WALO into game_relations.script and verified with new busted specs.
+
+
+## Prescope: Harden sim_offline_combat loops
+- **Task ID**: WALO port - Harden sim_offline_combat loops
+- **Agent**: DiffAnalysisAgent
+- **Summary**: Integrate loop improvements from old WALO to prevent index errors and ensure offline combat simulation stability.
+
+### Scope & Context
+- Affects `gamma_walo/gamedata/scripts/sim_offline_combat.script`.
+- Modifies loops in `smart_terrain_on_update`, `coordinator`, and related functions.
+- Uses engine hooks: `RegisterScriptCallback`, `alife`, `game_graph`.
+
+### Dependencies
+- Requires existing SIMBOARD and warfare options tables as per baseline.
+- No blocking tasks.
+
+### Data Flow Analysis
+- Inputs: tables of squads (`SIMBOARD.smarts[smart.id].squads`, `squads_by_level`).
+- Outputs: offline combat results via `simulate_battle` and stats updates.
+- Downstream: dynamic news, relation changes.
+
+### Failure Cases
+- Nil indexes in `ipairs` loops could skip elements or error.
+- Early return waiting for SIMBOARD may stall simulation.
+
+### Test Plan
+- Busted spec scanning the script to ensure `ipairs(tbl_smart)` usage removed.
+- Verify absence of initialization guard line.
+
+### Rollback & Risk
+- Revert file to previous version if simulation misbehaves.
+- Tests guard against accidental reintroduction of fragile loops.

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -1,6 +1,6 @@
 [a] WALO port
 [x] Port dialogs.script helper and important_docs table (weight: 300)
-[ ] Harden sim_offline_combat loops (weight: 200)
+[x] Harden sim_offline_combat loops (weight: 200)
 [ ] Add nil checks to smart_terrain_warfare.script (weight: 150)
 [ ] Merge tasks_assault stability fixes (weight: 150)
 [ ] Merge tasks_smart_control stability fixes (weight: 100)

--- a/gamma_walo/gamedata/scripts/sim_offline_combat.script
+++ b/gamma_walo/gamedata/scripts/sim_offline_combat.script
@@ -115,13 +115,14 @@ local function smart_terrain_on_update(smart)
 		return
 	end
 	
-        shuffle_table(tbl_smart)
+       shuffle_table(tbl_smart)
 
-        local sim = alife()
+       local sim = alife()
+       local lid_1
 
-        for _,id_1 in ipairs(tbl_smart) do
-                local squad_1 = sim:object(id_1)
-                local section = squad_1 and squad_1:section_name()
+       for i,id_1 in pairs(tbl_smart) do
+               local squad_1 = sim:object(id_1)
+               local section = squad_1 and squad_1:section_name()
 		
 		if squad_1 and (not squad_1.online) and SIMBOARD.squads[squad_1.id] and (squad_1:npc_count() > 0)
 		then
@@ -130,8 +131,8 @@ local function smart_terrain_on_update(smart)
 				return
 			end
 	
-                        local lid_1 = game_graph():vertex(squad_1.m_game_vertex_id):level_id()
-                        if lid_1 and squads_by_level[lid_1] then
+                       lid_1 = lid_1 or game_graph():vertex(squad_1.m_game_vertex_id):level_id()
+                       if lid_1 and squads_by_level[lid_1] then
 				
 --				if (not task_squads[id_1]) and (not task_giver_squads[id_1]) then
 					-- disable offline combat for ignore list when Warfare is active
@@ -150,9 +151,9 @@ local function smart_terrain_on_update(smart)
 							end
 						end
 				
-                                                -- Otherwise, scan for squads in the same map
-                                                for _,id_2 in ipairs(tbl_smart) do
-                                                        in_combat = validate_enemy(sim, lid_1, squad_1, id_1, id_2, community_1)
+                                               -- Otherwise, scan for squads in the same map
+                                               for j,id_2 in pairs(tbl_smart) do
+                                                       in_combat = validate_enemy(sim, lid_1, squad_1, id_1, id_2, community_1)
 							if in_combat then
 								if enable_debug then
 									printf("% OCS | Battle in smart [%s]", smart:name())
@@ -242,10 +243,6 @@ end
 
 local function coordinator()
        ResetTimeEvent("cycle","ocs", UPDATE_TIME)
-
-       if not (SIMBOARD and SIMBOARD.smarts) then
-               return true -- wait until SIMBOARD initialized
-       end
 	
 	-- Toggle feature
 	

--- a/tests/sim_offline_combat_spec.lua
+++ b/tests/sim_offline_combat_spec.lua
@@ -1,0 +1,16 @@
+package.path = package.path .. ';gamma_walo/gamedata/scripts/?.script'
+
+-- simply read the file text to verify loop hardening
+local file = assert(io.open('gamma_walo/gamedata/scripts/sim_offline_combat.script'))
+local content = file:read('*all')
+file:close()
+
+describe('sim_offline_combat hardening', function()
+    it('uses pairs loops for smart_terrain scanning', function()
+        assert.is_nil(content:match('ipairs%(%s*tbl_smart'))
+    end)
+
+    it('does not wait for SIMBOARD initialization', function()
+        assert.is_nil(content:match('SIMBOARD and SIMBOARD%.smarts'))
+    end)
+end)


### PR DESCRIPTION
## Summary
- port old WALO loop improvements to sim_offline_combat.script
- add test ensuring pairs-based loops and removal of SIMBOARD guard
- document prescope and changelog entry

## Testing
- `busted -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6884df593100832eaa375b80852e28b1