### PR TITLE
Implement WALO-8 UI option tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - WALO-5: Applied loop optimisation and removed squad cap logic in sim_offline_combat.script
 - WALO-3: Verified simplified spawn chance formulas and added spec
 - WALO-4: Optimised blacklist loops in game_relations.script and added tests
+- WALO-8: Merged warfare tweak options into ui_options.script

--- a/DevDiary.md
+++ b/DevDiary.md
@@ -315,3 +315,42 @@
 ### Completed WALO-4
 - Applied blacklist loop optimisation in game_relations.script and added tests.
 - Date: 2025-07-26
+## Prescope: Merge warfare tweak options in ui_options.script
+- **Task ID**: WALO-8
+- **Agent**: DiffAnalysisAgent
+- **Summary**: Port old WALO UI option tweaks into gamma_walo to expose new gameplay sliders and limits while keeping MCM compatibility.
+
+### Complexity Classification
+- **Complexity**: [P-complete]
+- **Justification**: Straightforward text edits to an existing script with known diff.
+
+### Scope & Context
+- Modify `gamma_walo/gamedata/scripts/ui_options.script`.
+- No engine hooks affected; only menu option definitions.
+
+### Dependencies
+- None.
+
+### Data Flow Analysis
+- **Input**: Option definitions from old_walo version.
+- **Output**: Updated option table with new entries and tuned values.
+- **Consumers**: Options menu when loaded in-game.
+
+### Failure Cases
+- Syntax errors prevent options from loading.
+- Missing entries cause UI to misbehave.
+
+### Test Plan
+- Busted spec to check for new option entries (`thirst`, `sleep`).
+- Validate FOV maximum reduced to 140.
+
+### Rollback & Risk
+- Revert script if menu fails; minimal risk due to textual nature.
+
+### Definition of Done
+- `ui_options.script` contains new options and updated values.
+- Spec passes.
+- agent_prio updated and changelog entry written.
+### Completed WALO-8
+- Ported UI option tweaks from old_walo into gamma_walo/ui_options.script and added tests.
+- Date: 2025-07-26

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -3,6 +3,6 @@
   - [x] **WALO-4** Apply blacklist loop optimisations in game_relations.script (weight=150)
   - [ ] **WALO-6** Add nil checks in smart_terrain_warfare.script (weight=100)
   - [ ] **WALO-7** Apply stability fixes in tasks_assault.script and tasks_smart_control.script (weight=100)
-  - [ ] **WALO-8** Merge warfare tweak options in ui_options.script (weight=150)
+  - [x] **WALO-8** Merge warfare tweak options in ui_options.script (weight=150)
   - [ ] **WALO-9** Integrate scripted squad target fix in sim_squad_scripted.script (weight=100)
   - [ ] **WALO-10** Review remaining warfare scripts and merge functional changes (weight=50)

--- a/gamma_walo/gamedata/scripts/ui_options.script
+++ b/gamma_walo/gamedata/scripts/ui_options.script
@@ -26,8 +26,7 @@
 	2020/11/07 - Vintar - added resurgence chance as option
 	2021/02/13 - Vintar - added 'overflow overrides manual control' and 'extra loner fog of war' toggle, min smart targets per base
 	2021/11/09 - Vintar - added goodwill on kill options, added back "hide all smarts" option, added 'old autocapture' option
-        2022/02/26 - Vintar - added main base attack deprioritization option
-        2025/07/24 - d0pe - minor formatting cleanup
+       2022/02/26 - Vintar - added main base attack deprioritization option
 	
 --]]
 
@@ -101,7 +100,7 @@ options = {
 		{ id= "gamma"  		           ,type= "track"    ,val= 2	,cmd= "rs_c_gamma"					,min= 0.5  ,max= 1.5  ,step= 0.1 ,precondition= {for_renderer,"renderer_r1"}	},
 		{ id= "contrast"  	           ,type= "track"    ,val= 2	,cmd= "rs_c_contrast"				,min= 0.5  ,max= 1.5  ,step= 0.1 ,precondition= {for_renderer,"renderer_r1"}	},
 		{ id= "brightness"             ,type= "track"    ,val= 2	,cmd= "rs_c_brightness"				,min= 0.5  ,max= 1.5  ,step= 0.1 ,precondition= {for_renderer,"renderer_r1"}	},
-		{ id= "fov"  		           ,type= "track"    ,val= 2	,cmd= "fov"							,min= 5    ,max= 180  ,step= 1 },
+		{ id= "fov"  		           ,type= "track"    ,val= 2	,cmd= "fov"							,min= 5    ,max= 140  ,step= 1 },
 		{ id= "hud_fov"  	           ,type= "track"    ,val= 2	,cmd= "hud_fov"						,min= 0.1  ,max= 1    ,step= 0.01 },
 		{ id= "screen_mode"            ,type= "radio_h"  ,val= 2	,curr= {curr_screen_mode} 			,content= {{1,"fullscreen"} , {2,"borderless"} , {3,"windowed"}} 	,functor = {func_screen_mode}		},
 		{ id= "lighting"  		       ,type= "button"   ,functor_ui= {start_lighting_ui}  				,precondition= {level_present}		,precondition_1= {for_renderer,"renderer_r2a","renderer_r2","renderer_r2.5","renderer_r3","renderer_r4"}    },
@@ -125,7 +124,7 @@ options = {
 		{ id= "texture_lod"            ,type= "track"    ,val= 2	,cmd= "texture_lod"	                ,min= 0     ,max= 4     ,step= 1 	,no_str= true	  ,invert= true     ,vid= true	,restart= true	},
 		{ id= "geometry_lod"           ,type= "track"    ,val= 2	,cmd= "r__geometry_lod"	            ,min= 0.1   ,max= 1.5   ,step= 0.1 },
 		{ id= "mipbias"           	   ,type= "track"    ,val= 2	,cmd= "r__tf_mipbias"	            ,min= -0.5  ,max= 0.5   ,step= 0.1 	,no_str= true 	  ,invert= true },
-                { id= "tf_aniso"               ,type= "track"    ,val= 2       ,cmd= "r__tf_aniso"                      ,min= 1     ,max= 16    ,step= 4    ,vid= true  },
+                { id= "tf_aniso"               ,type= "list"     ,val= 0       ,cmd= "r__tf_aniso"                      ,content={ {"1","st_opt_off"},{"4","x4"},{"8","x8"},{"16","x16"} }    ,vid= true, no_str= true  },
 		{ id= "ssample"                ,type= "track"    ,val= 2	,cmd= "r__supersample"	            ,min= 1     ,max= 8     ,step= 1       ,vid= true      ,precondition= {for_renderer,"renderer_r1","renderer_r2a","renderer_r2","renderer_r2.5"} },
 		{ id= "ssample_list"           ,type= "list"     ,val= 0	,cmd= "r3_msaa"	                    ,content={ {"st_opt_off","st_opt_off"},{"2x","x2"},{"4x","x4"},{"8x","x8"} }	    ,vid= true          ,precondition= {for_renderer,"renderer_r3","renderer_r4"} , no_str= true  },
 		{ id= "smaa"           		   ,type= "list"     ,val= 0	,cmd= "r2_smaa"	                    ,content={ {"off","st_opt_off"},{"low","st_opt_low"},{"medium","st_opt_medium"},{"high","st_opt_high"},{"ultra","st_opt_ultra"} } ,precondition= {for_renderer,"renderer_r2a","renderer_r2","renderer_r2.5","renderer_r3","renderer_r4"}, no_str= true  },
@@ -362,6 +361,8 @@ options = {
 		{ id= "dispersion_factor"    	 ,type= "track"    ,val= 2	,curr= {curr_gameplay,"dispersion_factor"}	 ,functor= {func_gameplay_diff,"dispersion_factor"}	,min= 1       ,max= 5     ,step= 0.1  	    },
 		{ id= "power_loss_bias"    	     ,type= "track"    ,val= 2	,curr= {curr_gameplay,"power_loss_bias"}	 ,functor= {func_gameplay_diff,"power_loss_bias"}	,min= 0.0     ,max= 1     ,step= 0.05  		},
 		{ id= "weight"    	     		 ,type= "track"    ,val= 2	,curr= {curr_gameplay,"weight"}	     		 ,functor= {func_gameplay_diff,"weight"}	 		,min= 10      ,max= 50    ,step= 1  	    },
+                { id= "thirst"                           ,type= "check"    ,val= 1      ,curr= {curr_gameplay,"thirst"}                  ,functor= {func_gameplay_diff,"thirst"}                                                               },
+                { id= "sleep"                            ,type= "check"    ,val= 1      ,curr= {curr_gameplay,"sleep"}                   ,functor= {func_gameplay_diff,"sleep"}                                                                },
 		{ id= "radiation_day"    	     ,type= "check"    ,val= 1	,curr= {curr_gameplay,"radiation_day"}	     ,functor= {func_gameplay_diff,"radiation_day"}	     	                   	 					},
 		{ id= "notify_geiger"    	     ,type= "check"    ,val= 1	,curr= {curr_gameplay,"notify_geiger"}	     ,functor= {func_gameplay_diff,"notify_geiger"}	     	                   	 					},
 		{ id= "notify_anomaly"    	     ,type= "check"    ,val= 1	,curr= {curr_gameplay,"notify_anomaly"}	     ,functor= {func_gameplay_diff,"notify_anomaly"}	     	                   	 				},
@@ -430,8 +431,8 @@ options = {
 	{ id= "general"      	,sh=true ,gr={
 		{ id= "slide_alife"		,type= "slide"	  ,link= "ui_options_slider_alife"	 ,text= "ui_mm_title_alife"		,size= {512,50}		},
 
-                { id= "alife_mutant_pop"                ,type= "list"    ,val= 2  ,def= 0.75     ,content= {{0.25} , {0.5} , {0.75} , {1}}              ,no_str= true  },
-                { id= "alife_stalker_pop"               ,type= "list"    ,val= 2  ,def= 0.5      ,content= {{0.25} , {0.5} , {0.75} , {1}}              ,no_str= true  },
+                { id= "alife_mutant_pop"                ,type= "list"    ,val= 2  ,def= 1.5      ,content= {{0.25} , {0.5} , {0.75} , {1}, {1.5}, {2}, {3}}              ,no_str= true  },
+                { id= "alife_stalker_pop"               ,type= "list"    ,val= 2  ,def= 1        ,content= {{0.25} , {0.5} , {0.75} , {1}, {1.5}, {2}}              ,no_str= true  },
 		{ id= "offline_combat"  		,type= "list"    ,val= 0  ,def= "full" 	 ,content= {{"full","full"}, {"on_smarts_only","on_smarts_only"}, {"off","off"}} },
 		{ id= "excl_dist"  				,type= "list"    ,val= 2  ,def= 75 	 	 ,content= {{0} , {25} , {50} , {75} , {100}}	,no_str= true  },
 		{ id= "dynamic_anomalies"        ,type= "check"    ,val= 1	,def= true	 },
@@ -1711,7 +1712,7 @@ function UIOptions:Callback_Input(ctrl, path, opt, v)
 		return
 	end
 	
-	if (v.val == 1) then
+	if (v.val == 2) then
 		value = tonumber(value)
 		if (not value) then
 			ctrl:SetText( self:GetCurrentValue(path, opt, v) or self:GetDefaultValue(path, opt, v) )

--- a/spec/walo_8_ui_options_spec.lua
+++ b/spec/walo_8_ui_options_spec.lua
@@ -1,0 +1,14 @@
+describe('WALO-8 ui_options tweaks', function()
+  local f = assert(io.open('gamma_walo/gamedata/scripts/ui_options.script', 'r'))
+  local data = f:read('*all')
+  f:close()
+
+  it('caps FOV max at 140', function()
+    assert.is_not_nil(string.find(data, 'id= "fov".-max= 140'))
+  end)
+
+  it('includes thirst and sleep options', function()
+    assert.is_not_nil(data:find('id= "thirst"'))
+    assert.is_not_nil(data:find('id= "sleep"'))
+  end)
+end)


### PR DESCRIPTION
## Summary
- port UI tweak options from old_walo into `ui_options.script`
- add thirst/sleep options and reduce FOV max
- add tests for new options
- note completion of WALO-8 in dev diary and changelog

## Testing
- `busted -v`

------
https://chatgpt.com/codex/tasks/task_e_68851ae18654832e93b3f7ac78d21529